### PR TITLE
CSS: Add horizontal padding to section elements

### DIFF
--- a/css/main_v7.css
+++ b/css/main_v7.css
@@ -39,6 +39,7 @@ body {
 
 section {
 	margin:40px 0;
+	padding:0 20px;
 }
 
 #identity #icon {


### PR DESCRIPTION
Noticed that the page could use a bit of horizontal padding, especially on smaller screen sizes, as to not make the text and other content go completely edge-to-edge.

To address that, this patch adds 20px of horizontal padding to all section elements.

Screenshot after the change:
<img width="612" alt="Screen Shot 2020-06-03 at 23 55 55" src="https://user-images.githubusercontent.com/2466701/83693147-c510bb00-a5f5-11ea-8e52-00755cb3d25b.png">